### PR TITLE
PHPCodesnifferの導入

### DIFF
--- a/backend/app/Http/Controllers/Controller.php
+++ b/backend/app/Http/Controllers/Controller.php
@@ -9,5 +9,7 @@ use Illuminate\Routing\Controller as BaseController;
 
 class Controller extends BaseController
 {
-    use AuthorizesRequests, DispatchesJobs, ValidatesRequests;
+    use AuthorizesRequests;
+    use DispatchesJobs;
+    use ValidatesRequests;
 }

--- a/backend/app/Models/User.php
+++ b/backend/app/Models/User.php
@@ -11,7 +11,9 @@ use Laravel\Sanctum\HasApiTokens;
 
 class User extends Authenticatable
 {
-    use HasApiTokens, HasFactory, Notifiable;
+    use HasApiTokens;
+    use HasFactory;
+    use Notifiable;
 
     /**
      * The attributes that are mass assignable.

--- a/backend/composer.json
+++ b/backend/composer.json
@@ -20,7 +20,8 @@
         "mockery/mockery": "^1.4.4",
         "nunomaduro/collision": "^6.1",
         "phpunit/phpunit": "^9.5.10",
-        "spatie/laravel-ignition": "^1.0"
+        "spatie/laravel-ignition": "^1.0",
+        "squizlabs/php_codesniffer": "^3.7"
     },
     "autoload": {
         "psr-4": {
@@ -47,6 +48,12 @@
         ],
         "post-create-project-cmd": [
             "@php artisan key:generate --ansi"
+        ],
+        "phpcs": [
+            "./vendor/bin/phpcs --standard=phpcs.xml ."
+        ],
+        "phpcbf": [
+            "./vendor/bin/phpcbf --standard=phpcs.xml ./"
         ]
     },
     "extra": {

--- a/backend/composer.lock
+++ b/backend/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "28bdb44ae83afb3ef858dd5e33b89383",
+    "content-hash": "d13d367f27b9cba68f315e0ceabb29fd",
     "packages": [
         {
             "name": "brick/math",
@@ -8254,6 +8254,62 @@
                 }
             ],
             "time": "2022-10-26T17:39:54+00:00"
+        },
+        {
+            "name": "squizlabs/php_codesniffer",
+            "version": "3.7.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/squizlabs/PHP_CodeSniffer.git",
+                "reference": "1359e176e9307e906dc3d890bcc9603ff6d90619"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/1359e176e9307e906dc3d890bcc9603ff6d90619",
+                "reference": "1359e176e9307e906dc3d890bcc9603ff6d90619",
+                "shasum": ""
+            },
+            "require": {
+                "ext-simplexml": "*",
+                "ext-tokenizer": "*",
+                "ext-xmlwriter": "*",
+                "php": ">=5.4.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^4.0 || ^5.0 || ^6.0 || ^7.0"
+            },
+            "bin": [
+                "bin/phpcs",
+                "bin/phpcbf"
+            ],
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.x-dev"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Greg Sherwood",
+                    "role": "lead"
+                }
+            ],
+            "description": "PHP_CodeSniffer tokenizes PHP, JavaScript and CSS files and detects violations of a defined set of coding standards.",
+            "homepage": "https://github.com/squizlabs/PHP_CodeSniffer",
+            "keywords": [
+                "phpcs",
+                "standards"
+            ],
+            "support": {
+                "issues": "https://github.com/squizlabs/PHP_CodeSniffer/issues",
+                "source": "https://github.com/squizlabs/PHP_CodeSniffer",
+                "wiki": "https://github.com/squizlabs/PHP_CodeSniffer/wiki"
+            },
+            "time": "2022-06-18T07:21:10+00:00"
         },
         {
             "name": "theseer/tokenizer",

--- a/backend/graphql/types/Response.graphql
+++ b/backend/graphql/types/Response.graphql
@@ -2,6 +2,6 @@ type Response {
     user: User!
     thread: Thread!
     body: String!
-    created_at: Date!
-    updated_at: Date
+    created_at: DateTime!
+    updated_at: DateTime
 }

--- a/backend/graphql/types/Thread.graphql
+++ b/backend/graphql/types/Thread.graphql
@@ -2,6 +2,6 @@ type Thread {
     user: User! @belongsTo
     title: String!
     responses: [Response]!
-    created_at: Date!
-    updated_at: Date
+    created_at: DateTime!
+    updated_at: DateTime
 }

--- a/backend/phpcs.xml
+++ b/backend/phpcs.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0"?>
+<ruleset name="PSR12">
+    <description>PSR12 compliant rules and settings for Laravel</description>
+    <!-- 拡張子が php のものにだけ適用 -->
+    <arg name="extensions" value="php" />
+    <!-- PSR12 コーディング規約の指定 -->
+    <rule ref="PSR12" />
+    <!-- 出力に色を適用 -->
+    <arg name="colors" />
+    <!-- オプション p:進捗表示  s:エラー表示時にルールを表示 -->
+    <arg value="ps" />
+
+    <!-- テストではメソッド名に日本語を使用することがあるので除外 -->
+    <rule ref="PSR1.Methods.CamelCapsMethodName.NotCamelCaps">
+        <exclude-pattern>*/tests/*</exclude-pattern>
+    </rule>
+
+    <!-- 除外ディレクトリ・ファイル-->
+    <exclude-pattern>/bootstrap/</exclude-pattern>
+    <exclude-pattern>/config/</exclude-pattern>
+    <exclude-pattern>/database/</exclude-pattern>
+    <exclude-pattern>/public/</exclude-pattern>
+    <exclude-pattern>/resources/</exclude-pattern>
+    <exclude-pattern>/routes/</exclude-pattern>
+    <exclude-pattern>/storage/</exclude-pattern>
+    <exclude-pattern>/vendor/</exclude-pattern>
+    <exclude-pattern>/app/Console/Kernel.php</exclude-pattern>
+    <exclude-pattern>/tests/CreatesApplication.php</exclude-pattern>
+</ruleset>


### PR DESCRIPTION
## やったこと  
- `squizlabs/php_codesniffer`をインストール
- `composer.json`のscriptに`phpcs`と`phpcbf`コマンドを追加
- phpcs.xmlファイルを作成し、PSR12のコーディング規約を指定し、カスタムをルールを追加
- phpcs実行による構文エラーの修正
- GraphQLのtypeファイルの修正

## 導入方法  
**インストール**  
下記のコマンドを実行し、インストール
```
composer require --dev squizlabs/php_codesniffer
```

**composer.jsonにコマンド追加**  
```json
{
    "scripts": { 
        "phpcs": [
            "./vendor/bin/phpcs --standard=phpcs.xml ./"
        ],
        "phpcbf": [
            "./vendor/bin/phpcbf --standard=phpcs.xml ./"
        ]
    },
}
```

**phpcs.xmlファイルを作成し、設定を記述**  
- 現状、開発を行うのに最低限のルールを追加している。開発を進めていく中で必要になったタイミングで追加ルールや除外ルールを足していきたい

